### PR TITLE
Event handling

### DIFF
--- a/evil-escape.el
+++ b/evil-escape.el
@@ -197,10 +197,12 @@ with a key sequence."
           (restore-buffer-modified-p modified)
           (cond
            ((and (characterp evt)
-                 (or (and (equal (this-command-keys) (evil-escape--first-key))
+                 (or (and (equal (this-command-keys-vector)
+                                 (evil-escape--first-key))
                           (char-equal evt skey))
                      (and evil-escape-unordered-key-sequence
-                          (equal (this-command-keys) (evil-escape--second-key))
+                          (equal (this-command-keys-vector)
+                                 (evil-escape--second-key))
                           (char-equal evt fkey))))
             (evil-repeat-stop)
             (let ((esc-fun (evil-escape-func)))
@@ -236,9 +238,9 @@ with a key sequence."
        (not (memq evil-state evil-escape-excluded-states))
        (or (not evil-escape-enable-only-for-major-modes)
            (memq major-mode evil-escape-enable-only-for-major-modes))
-       (or (equal (this-command-keys) (evil-escape--first-key))
+       (or (equal (this-command-keys-vector) (evil-escape--first-key))
            (and evil-escape-unordered-key-sequence
-                (equal (this-command-keys) (evil-escape--second-key))))
+                (equal (this-command-keys-vector) (evil-escape--second-key))))
        (not (cl-reduce (lambda (x y) (or x y))
                        (mapcar 'funcall evil-escape-inhibit-functions)
                        :initial-value nil))))
@@ -283,16 +285,14 @@ with a key sequence."
    (t 'evil-normal-state)))
 
 (defun evil-escape--first-key ()
-  "Return the first key string in the key sequence."
-  (let* ((first-key (elt evil-escape-key-sequence 0))
-         (fkeystr (char-to-string first-key)))
-    fkeystr))
+  "Return a vector containing just the first key in the key sequence."
+  (let ((first-key (elt evil-escape-key-sequence 0)))
+    (vector first-key)))
 
 (defun evil-escape--second-key ()
-  "Return the second key string in the key sequence."
-  (let* ((sec-key (elt evil-escape-key-sequence 1))
-         (fkeystr (char-to-string sec-key)))
-    fkeystr))
+  "Return a vector containing just the second key in the key sequence."
+  (let ((second-key (elt evil-escape-key-sequence 1)))
+    (vector second-key)))
 
 (defun evil-escape--insert-func ()
   "Default insert function."

--- a/evil-escape.el
+++ b/evil-escape.el
@@ -189,7 +189,7 @@ with a key sequence."
                (inserted (evil-escape--insert))
                (fkey (elt evil-escape-key-sequence 0))
                (skey (elt evil-escape-key-sequence 1))
-               (evt (read-event nil nil evil-escape-delay)))
+               (evt (read-event nil t evil-escape-delay)))
           (when inserted (evil-escape--delete))
           ;; NOTE Add syl20bnr/evil-escape#91: replace `set-buffer-modified-p'
           ;;      with `restore-buffer-modified-p', which doesn't redisplay the

--- a/evil-escape.el
+++ b/evil-escape.el
@@ -315,7 +315,7 @@ with a key sequence."
     ('error nil)))
 
 (defun evil-escape--insert-2 ()
-  "Insert character while taking into account mode specificites."
+  "Insert character while taking into account mode specificities."
   (pcase major-mode
     (`term-mode (call-interactively 'term-send-raw))
     (_ (cond
@@ -333,7 +333,7 @@ with a key sequence."
     (`iedit-insert (evil-escape--delete-func))))
 
 (defun evil-escape--delete-2 ()
-  "Delete character while taking into account mode specifities."
+  "Delete character while taking into account mode specificities."
   (pcase major-mode
     (`term-mode (call-interactively 'term-send-backspace))
     (_ (cond


### PR DESCRIPTION
Commits 130219b and 819f1ee, which fixed the macro-record bug, introduced another bug which only manifests itself when using an alternative input method. This branch fixes that, while also resolving a different problem with input methods that already existed in the upstream (see https://github.com/syl20bnr/evil-escape/issues/51).

Say your escape sequence is `jk`. Do a `C-\` to switch to the input method `programmer-dvorak`. (Be advised: this only translates keystrokes in evil's insert and replace modes, and it doesn't translate any key-modifier combinations in any mode.)

Now you'd think you could trigger an escape by typing "jk" with the physical keys C and V -- or, failing that, at least by hitting the now-translated physical keys J and K. Instead, the physical key sequence you need is their bastard child CK. What's worse, if you hold down the C key, and if your OS passes repeated keystrokes to Emacs fast enough, the string inserted into the buffer is "jcjcjcjcjcjcjc".

Problem: `evil-escape-pre-command-hook`, when waiting for the second character of the escape sequence, binds `evt` with a call to `read-event` that doesn't request input method processing. This means it matches against the escape sequence based on an untranslated keystroke. It also means it pushes the untranslated keystroke straight onto the post-input-method event queue, from which its binding is looked up directly.

Just telling `read-event` to handle the input method is enough to fix the behavior. And this doesn't reintroduce the earlier bug; the change in argument to `read-event` leaves macro recording alone. The extra processing step doesn't make any discernible difference, either perceptually or in the profiler. (The pre-command hook is effectively a deep inner loop if you're doing something like scrolling, but the call to `read-event` never happens unless the last event was the first half of the escape sequence.)

As for the upstream bug: that was caused by `this-command-keys` being so obnoxious as to return different sequence types depending on the values of the elements (!). All salient details are in the commit message.